### PR TITLE
Updating res.sendfile to res.sendFile (and added root path)

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -240,7 +240,7 @@ module.exports = function(grunt) {
         // If there are query parameters, remove them.
         filename = filename.split("?")[0];
 
-        res.sendfile(path.join(normalizePath, filename));
+        res.sendFile(path.join(normalizePath, filename), { root: './' });
       });
     });
 
@@ -331,7 +331,7 @@ module.exports = function(grunt) {
         if (!exists || filename.slice(-1) === path.sep) {
           next();
         } else {
-          res.sendfile(filename);
+          res.sendFile(filename, {root: './'});
         }
       });
     });


### PR DESCRIPTION
This suppresses the warning stating that res.senfile is deprecated in favor of the new res.sendFile.  The new command (res.sendFile) requires that a root path be added also, so I've done that as well.
