### PR TITLE
Fixed "Cannot read property 'prototype' of undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-lib-less": "~0.1.0",
     "grunt-lib-stylus": "~0.1.0",
     "gzip-js": "~0.3.2",
-    "http-proxy": "~1.3.0",
+    "http-proxy": "~1.11.1",
     "requirejs": "~2.1.14"
   }
 }


### PR DESCRIPTION
Related: nodejitsu/node-http-proxy/issues/809

trace:

```
Registering "grunt-bbb-server" local Npm module tasks.
Reading /DIR/node_modules/grunt-bbb-server/package.json...OK
Parsing /DIR/node_modules/grunt-bbb-server/package.json...OK
Loading "server.js" tasks...ERROR
>> TypeError: Cannot read property 'prototype' of undefined
>>     at Object.exports.inherits (util.js:634:43)
>>     at Object.<anonymous> (/DIR/node_modules/grunt-bbb-server/node_modules/http-proxy/lib/http-proxy/index.js:108:17)
>>     at Module._compile (module.js:460:26)
>>     at Object.Module._extensions..js (module.js:478:10)
>>     at Module.load (module.js:355:32)
>>     at Function.Module._load (module.js:310:12)
>>     at Module.require (module.js:365:17)
>>     at require (module.js:384:17)
>>     at Object.<anonymous> (/DIR/node_modules/grunt-bbb-server/node_modules/http-proxy/lib/http-proxy.js:4:17)
>>     at Module._compile (module.js:460:26)

```
