### PR TITLE
Remove ES5 jshint requirement

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }


### PR DESCRIPTION
This doesn't fix the build error, but it does "fix" the jshint errors that are popping up.
